### PR TITLE
glaze error mechanism changed

### DIFF
--- a/src/serializer.glaze.cpp
+++ b/src/serializer.glaze.cpp
@@ -38,7 +38,7 @@ namespace saucer::serializers
     }
 
     template <typename T>
-    tl::expected<T, glz::parse_error> parse_as(const std::string &buffer)
+    auto parse_as(const std::string &buffer)
     {
         static constexpr auto opts = glz::opts{.error_on_missing_keys = true, .raw_string = false};
 


### PR DESCRIPTION
parse_error now is error_ctx, `auto` should be okay for both versions