### PR TITLE
Upgrade ICoreWebView2_2 to ICoreWebView2_3

### DIFF
--- a/include/saucer/modules/stable/webview2.hpp
+++ b/include/saucer/modules/stable/webview2.hpp
@@ -26,7 +26,7 @@ namespace saucer
     template <>
     struct stable_natives<webview>
     {
-        ICoreWebView2_2 *webview;
+        ICoreWebView2_3 *webview;
         ICoreWebView2Controller *controller;
     };
 } // namespace saucer

--- a/private/saucer/wv2.webview.impl.hpp
+++ b/private/saucer/wv2.webview.impl.hpp
@@ -31,7 +31,7 @@ namespace saucer
     {
         ComPtr<ICoreWebView2Controller> controller;
         ComPtr<ICoreWebView2Settings> settings;
-        ComPtr<ICoreWebView2_2> web_view;
+        ComPtr<ICoreWebView2_3> web_view;
 
       public:
         icon favicon;


### PR DESCRIPTION
Very simple PR that simply uses `ICoreWebView2_3` instead of `ICoreWebView2_2`.
The `ICoreWebView2_3` version has a `TrySuspend()` method that would be useful for me and probably others as well.