### PR TITLE
feat(scheme): add streaming scheme support

### DIFF
--- a/include/saucer/scheme.hpp
+++ b/include/saucer/scheme.hpp
@@ -58,4 +58,35 @@ namespace saucer::scheme
 
     using executor = saucer::executor<response, error>;
     using resolver = std::function<void(request, executor)>;
+
+    struct stream_response
+    {
+        std::string mime;
+        std::map<std::string, std::string> headers;
+        int status{200};
+    };
+
+    class stream_writer
+    {
+      public:
+        struct impl;
+
+      private:
+        std::shared_ptr<impl> m_impl;
+
+      public:
+        stream_writer(std::shared_ptr<impl>);
+        stream_writer(const stream_writer &);
+        stream_writer(stream_writer &&) noexcept;
+        ~stream_writer();
+
+      public:
+        void start(const stream_response &);
+        void write(stash data);
+        void finish();
+        void reject(error err);
+        [[nodiscard]] bool valid() const;
+    };
+
+    using stream_resolver = std::function<void(request, stream_writer)>;
 } // namespace saucer::scheme

--- a/include/saucer/webview.hpp
+++ b/include/saucer/webview.hpp
@@ -198,6 +198,10 @@ namespace saucer
         [[sc::thread_safe]] void remove_scheme(const std::string &name);
 
       public:
+        [[sc::thread_safe]] void handle_stream_scheme(const std::string &name, scheme::stream_resolver &&handler);
+        [[sc::thread_safe]] void remove_stream_scheme(const std::string &name);
+
+      public:
         template <event Event>
         [[sc::thread_safe]] auto on(events::event<Event>::listener);
 

--- a/private/saucer/qt.scheme.impl.hpp
+++ b/private/saucer/qt.scheme.impl.hpp
@@ -28,4 +28,26 @@ namespace saucer::scheme
       public:
         void requestStarted(QWebEngineUrlRequestJob *) override;
     };
+
+    class stream_handler : public QWebEngineUrlSchemeHandler
+    {
+        scheme::stream_resolver resolver;
+
+      public:
+        stream_handler(scheme::stream_resolver);
+
+      public:
+        stream_handler(stream_handler &&) noexcept;
+
+      public:
+        void requestStarted(QWebEngineUrlRequestJob *) override;
+    };
+
+    struct stream_writer::impl
+    {
+        std::shared_ptr<lockpp::lock<QWebEngineUrlRequestJob *>> request;
+        class stream_device *device;
+        std::atomic<bool> started{false};
+        std::atomic<bool> finished{false};
+    };
 } // namespace saucer::scheme

--- a/private/saucer/qt.webview.impl.hpp
+++ b/private/saucer/qt.webview.impl.hpp
@@ -64,6 +64,7 @@ namespace saucer
       public:
         std::unique_ptr<request_interceptor> interceptor;
         std::unordered_map<std::string, scheme::handler> schemes;
+        std::unordered_map<std::string, scheme::stream_handler> stream_schemes;
 
       public:
         template <event>

--- a/private/saucer/webview.impl.hpp
+++ b/private/saucer/webview.impl.hpp
@@ -38,6 +38,7 @@ namespace saucer
       public:
         void handle_embed(const scheme::request &, const scheme::executor &);
         void handle_scheme(const std::string &, scheme::resolver &&);
+        void handle_stream_scheme(const std::string &, scheme::stream_resolver &&);
 
       public:
         void reject(std::size_t, std::string_view);
@@ -94,6 +95,7 @@ namespace saucer
 
       public:
         void remove_scheme(const std::string &);
+        void remove_stream_scheme(const std::string &);
         static void register_scheme(const std::string &);
 
       public:

--- a/private/saucer/wk.scheme.impl.hpp
+++ b/private/saucer/wk.scheme.impl.hpp
@@ -15,14 +15,25 @@ namespace saucer::scheme
     {
         task_ref task;
     };
+
+    struct stream_writer::impl
+    {
+        task_ref task;
+        lockpp::lock<std::unordered_map<NSUInteger, task_ref>> *tasks;
+        NSUInteger handle;
+        std::atomic<bool> started{false};
+        std::atomic<bool> finished{false};
+    };
 } // namespace saucer::scheme
 
 @interface SchemeHandler : NSObject <WKURLSchemeHandler>
 {
   @public
     std::unordered_map<WKWebView *, saucer::scheme::resolver> m_callbacks;
+    std::unordered_map<WKWebView *, saucer::scheme::stream_resolver> m_stream_callbacks;
     lockpp::lock<std::unordered_map<NSUInteger, saucer::scheme::task_ref>> m_tasks;
 }
 - (void)add_callback:(saucer::scheme::resolver)callback webview:(WKWebView *)instance;
+- (void)add_stream_callback:(saucer::scheme::stream_resolver)callback webview:(WKWebView *)instance;
 - (void)del_callback:(WKWebView *)instance;
 @end

--- a/private/saucer/wkg.scheme.impl.hpp
+++ b/private/saucer/wkg.scheme.impl.hpp
@@ -24,4 +24,24 @@ namespace saucer::scheme
       public:
         static void handle(WebKitURISchemeRequest *, handler *);
     };
+
+    class stream_handler
+    {
+        std::unordered_map<WebKitWebView *, scheme::stream_resolver> m_callbacks;
+
+      public:
+        void add_callback(WebKitWebView *, scheme::stream_resolver);
+        void del_callback(WebKitWebView *);
+
+      public:
+        static void handle(WebKitURISchemeRequest *, stream_handler *);
+    };
+
+    struct stream_writer::impl
+    {
+        utils::g_object_ptr<WebKitURISchemeRequest> request;
+        int write_fd{-1};
+        std::atomic<bool> started{false};
+        std::atomic<bool> finished{false};
+    };
 } // namespace saucer::scheme

--- a/private/saucer/wkg.webview.impl.hpp
+++ b/private/saucer/wkg.webview.impl.hpp
@@ -69,5 +69,6 @@ namespace saucer
       public:
         static WebKitSettings *make_settings(const options &);
         static inline std::unordered_map<std::string, std::unique_ptr<scheme::handler>> schemes;
+        static inline std::unordered_map<std::string, std::unique_ptr<scheme::stream_handler>> stream_schemes;
     };
 } // namespace saucer

--- a/private/saucer/wv2.scheme.impl.hpp
+++ b/private/saucer/wv2.scheme.impl.hpp
@@ -5,6 +5,12 @@
 #include <wrl.h>
 #include <WebView2.h>
 
+#include <lockpp/lock.hpp>
+
+#include <deque>
+#include <mutex>
+#include <condition_variable>
+
 namespace saucer::scheme
 {
     using Microsoft::WRL::ComPtr;
@@ -13,5 +19,43 @@ namespace saucer::scheme
     {
         ComPtr<ICoreWebView2WebResourceRequest> request;
         ComPtr<IStream> body;
+    };
+
+    class stream_buffer : public IStream
+    {
+        LONG m_ref{1};
+        std::mutex m_mutex;
+        std::condition_variable m_cv;
+        std::deque<std::uint8_t> m_buffer;
+        bool m_finished{false};
+
+      public:
+        void push(const std::uint8_t *data, std::size_t size);
+        void close_write();
+
+        HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppv) override;
+        ULONG STDMETHODCALLTYPE AddRef() override;
+        ULONG STDMETHODCALLTYPE Release() override;
+        HRESULT STDMETHODCALLTYPE Read(void *pv, ULONG cb, ULONG *pcbRead) override;
+        HRESULT STDMETHODCALLTYPE Write(const void *, ULONG, ULONG *) override;
+        HRESULT STDMETHODCALLTYPE Seek(LARGE_INTEGER, DWORD, ULARGE_INTEGER *) override;
+        HRESULT STDMETHODCALLTYPE SetSize(ULARGE_INTEGER) override;
+        HRESULT STDMETHODCALLTYPE CopyTo(IStream *, ULARGE_INTEGER, ULARGE_INTEGER *, ULARGE_INTEGER *) override;
+        HRESULT STDMETHODCALLTYPE Commit(DWORD) override;
+        HRESULT STDMETHODCALLTYPE Revert() override;
+        HRESULT STDMETHODCALLTYPE LockRegion(ULARGE_INTEGER, ULARGE_INTEGER, DWORD) override;
+        HRESULT STDMETHODCALLTYPE UnlockRegion(ULARGE_INTEGER, ULARGE_INTEGER, DWORD) override;
+        HRESULT STDMETHODCALLTYPE Stat(STATSTG *pstatstg, DWORD) override;
+        HRESULT STDMETHODCALLTYPE Clone(IStream **) override;
+    };
+
+    struct stream_writer::impl
+    {
+        ComPtr<ICoreWebView2WebResourceRequestedEventArgs> args;
+        ComPtr<ICoreWebView2Deferral> deferral;
+        ComPtr<ICoreWebView2Environment> environment;
+        stream_buffer *buffer{nullptr};
+        std::atomic<bool> started{false};
+        std::atomic<bool> finished{false};
     };
 } // namespace saucer::scheme

--- a/private/saucer/wv2.webview.impl.hpp
+++ b/private/saucer/wv2.webview.impl.hpp
@@ -72,6 +72,7 @@ namespace saucer
         std::size_t id_counter{0};
         std::map<std::size_t, wv2_script> scripts;
         std::unordered_map<std::string, scheme::resolver> schemes;
+        std::unordered_map<std::string, scheme::stream_resolver> stream_schemes;
 
       public:
         std::size_t on_resize, on_minimize;

--- a/src/qt.scheme.cpp
+++ b/src/qt.scheme.cpp
@@ -3,6 +3,9 @@
 #include "qt.url.impl.hpp"
 
 #include <ranges>
+#include <deque>
+#include <mutex>
+#include <condition_variable>
 
 #include <QMap>
 #include <QBuffer>
@@ -10,6 +13,165 @@
 
 namespace saucer::scheme
 {
+    class stream_device : public QIODevice
+    {
+        mutable std::mutex m_mutex;
+        std::condition_variable m_cv;
+        std::deque<std::uint8_t> m_buffer;
+        bool m_finished{false};
+
+      public:
+        stream_device(QObject *parent = nullptr) : QIODevice(parent)
+        {
+            open(QIODevice::ReadOnly);
+        }
+
+        void push(const std::uint8_t *data, std::size_t size)
+        {
+            {
+                std::lock_guard lock{m_mutex};
+                m_buffer.insert(m_buffer.end(), data, data + size);
+            }
+            m_cv.notify_one();
+            QMetaObject::invokeMethod(this, &QIODevice::readyRead, Qt::QueuedConnection);
+        }
+
+        void close_write()
+        {
+            {
+                std::lock_guard lock{m_mutex};
+                m_finished = true;
+            }
+            m_cv.notify_one();
+            QMetaObject::invokeMethod(this, &QIODevice::readyRead, Qt::QueuedConnection);
+        }
+
+        bool isSequential() const override { return true; }
+        qint64 bytesAvailable() const override
+        {
+            std::lock_guard lock{m_mutex};
+            return static_cast<qint64>(m_buffer.size()) + QIODevice::bytesAvailable();
+        }
+
+      protected:
+        qint64 readData(char *data, qint64 max) override
+        {
+            std::unique_lock lock{m_mutex};
+            m_cv.wait(lock, [this] { return !m_buffer.empty() || m_finished; });
+
+            if (m_buffer.empty())
+            {
+                return m_finished ? -1 : 0;
+            }
+
+            auto to_read = std::min(static_cast<std::size_t>(max), m_buffer.size());
+            std::copy_n(m_buffer.begin(), to_read, data);
+            m_buffer.erase(m_buffer.begin(), m_buffer.begin() + static_cast<std::ptrdiff_t>(to_read));
+
+            return static_cast<qint64>(to_read);
+        }
+
+        qint64 writeData(const char *, qint64) override { return -1; }
+    };
+
+    stream_writer::stream_writer(std::shared_ptr<impl> impl) : m_impl(std::move(impl)) {}
+    stream_writer::stream_writer(const stream_writer &) = default;
+    stream_writer::stream_writer(stream_writer &&) noexcept = default;
+    stream_writer::~stream_writer() = default;
+
+    void stream_writer::start(const stream_response &response)
+    {
+        if (!m_impl || m_impl->started.exchange(true) || m_impl->finished)
+        {
+            return;
+        }
+
+        auto req = m_impl->request->write();
+        if (!req.value())
+        {
+            m_impl->started = false;
+            return;
+        }
+
+        auto to_array = [](auto &item)
+        {
+            return std::make_pair(QByteArray::fromStdString(item.first), QByteArray::fromStdString(item.second));
+        };
+
+        const auto headers   = std::views::transform(response.headers, to_array);
+        const auto converted = QMultiMap<QByteArray, QByteArray>{{headers.begin(), headers.end()}};
+
+        req.value()->setAdditionalResponseHeaders(converted);
+        req.value()->reply(QString::fromStdString(response.mime).toUtf8(), m_impl->device);
+    }
+
+    void stream_writer::write(stash data)
+    {
+        if (!m_impl || !m_impl->started || m_impl->finished)
+        {
+            return;
+        }
+
+        m_impl->device->push(data.data(), data.size());
+    }
+
+    void stream_writer::finish()
+    {
+        if (!m_impl || !m_impl->started || m_impl->finished.exchange(true))
+        {
+            return;
+        }
+
+        m_impl->device->close_write();
+    }
+
+    void stream_writer::reject(error err)
+    {
+        if (!m_impl || m_impl->finished.exchange(true))
+        {
+            return;
+        }
+
+        auto req = m_impl->request->write();
+        if (!req.value())
+        {
+            return;
+        }
+
+        QWebEngineUrlRequestJob::Error qt_err{};
+
+        switch (err)
+        {
+            using enum scheme::error;
+            using enum QWebEngineUrlRequestJob::Error;
+
+        case not_found:
+            qt_err = UrlNotFound;
+            break;
+        case invalid:
+            qt_err = UrlInvalid;
+            break;
+        case denied:
+            qt_err = RequestDenied;
+            break;
+        case failed:
+            qt_err = RequestFailed;
+            break;
+        }
+
+        req.value()->fail(qt_err);
+    }
+
+    bool stream_writer::valid() const
+    {
+        if (!m_impl)
+        {
+            return false;
+        }
+
+        auto req = m_impl->request->write();
+        return req.value() && !m_impl->finished;
+    }
     request::request(impl data) : m_impl(std::make_unique<impl>(std::move(data))) {}
 
     request::request(const request &other) : request(*other.m_impl) {}
@@ -141,5 +303,43 @@ namespace saucer::scheme
         connect(raw, &QObject::destroyed, [request]() { request->assign(nullptr); });
 
         return resolver(std::move(req), std::move(executor));
+    }
+
+    stream_handler::stream_handler(scheme::stream_resolver resolver) : resolver(std::move(resolver)) {}
+
+    stream_handler::stream_handler(stream_handler &&other) noexcept : resolver(std::move(other.resolver)) {}
+
+    void stream_handler::requestStarted(QWebEngineUrlRequestJob *raw)
+    {
+        if (!resolver)
+        {
+            return;
+        }
+
+        auto request = std::make_shared<lockpp::lock<QWebEngineUrlRequestJob *>>(raw);
+        auto content = QByteArray{};
+
+        auto *const body = raw->requestBody();
+
+        if (body && body->open(QIODevice::OpenModeFlag::ReadOnly))
+        {
+            content = body->readAll();
+        }
+
+        auto *device      = new stream_device{raw};
+        auto writer_impl  = std::make_shared<stream_writer::impl>();
+        writer_impl->request = request;
+        writer_impl->device  = device;
+
+        auto writer = stream_writer{writer_impl};
+        auto req    = scheme::request{{.request = request, .body = std::move(content)}};
+
+        connect(raw, &QObject::destroyed, [request, device]()
+        {
+            request->assign(nullptr);
+            device->close_write();
+        });
+
+        return resolver(std::move(req), std::move(writer));
     }
 } // namespace saucer::scheme

--- a/src/qt.webview.cpp
+++ b/src/qt.webview.cpp
@@ -391,6 +391,17 @@ namespace saucer
         platform->web_view->page()->profile()->installUrlSchemeHandler(QByteArray::fromStdString(name), &scheme);
     }
 
+    void impl::handle_stream_scheme(const std::string &name, scheme::stream_resolver &&resolver) // NOLINT(*-function-const)
+    {
+        if (platform->stream_schemes.contains(name))
+        {
+            return;
+        }
+
+        auto &scheme = platform->stream_schemes.emplace(name, std::move(resolver)).first->second;
+        platform->web_view->page()->profile()->installUrlSchemeHandler(QByteArray::fromStdString(name), &scheme);
+    }
+
     void impl::remove_scheme(const std::string &name) // NOLINT(*-function-const)
     {
         const auto it = platform->schemes.find(name);
@@ -402,6 +413,19 @@ namespace saucer
 
         platform->web_view->page()->profile()->removeUrlSchemeHandler(&it->second);
         platform->schemes.erase(it);
+    }
+
+    void impl::remove_stream_scheme(const std::string &name) // NOLINT(*-function-const)
+    {
+        const auto it = platform->stream_schemes.find(name);
+
+        if (it == platform->stream_schemes.end())
+        {
+            return;
+        }
+
+        platform->web_view->page()->profile()->removeUrlSchemeHandler(&it->second);
+        platform->stream_schemes.erase(it);
     }
 
     void impl::register_scheme(const std::string &name)

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -110,6 +110,11 @@ namespace saucer
         return utils::invoke<&impl::handle_scheme>(m_impl.get(), name, std::move(handler));
     }
 
+    void webview::handle_stream_scheme(const std::string &name, scheme::stream_resolver &&handler)
+    {
+        return utils::invoke<&impl::handle_stream_scheme>(m_impl.get(), name, std::move(handler));
+    }
+
     void impl::reject(std::size_t id, std::string_view reason)
     {
         static constexpr auto code = R"(
@@ -299,6 +304,11 @@ namespace saucer
     void webview::remove_scheme(const std::string &name)
     {
         return utils::invoke<&impl::remove_scheme>(m_impl.get(), name);
+    }
+
+    void webview::remove_stream_scheme(const std::string &name)
+    {
+        return utils::invoke<&impl::remove_stream_scheme>(m_impl.get(), name);
     }
 
     void webview::off(event event)

--- a/src/wk.scheme.impl.mm
+++ b/src/wk.scheme.impl.mm
@@ -1,7 +1,180 @@
 #include "wk.scheme.impl.hpp"
 
+#include <dispatch/dispatch.h>
+
 using namespace saucer;
 using namespace saucer::scheme;
+
+stream_writer::stream_writer(std::shared_ptr<impl> impl) : m_impl(std::move(impl)) {}
+
+stream_writer::stream_writer(const stream_writer &) = default;
+
+stream_writer::stream_writer(stream_writer &&) noexcept = default;
+
+stream_writer::~stream_writer() = default;
+
+void stream_writer::start(const stream_response &response)
+{
+    if (!m_impl || m_impl->started.exchange(true) || m_impl->finished)
+    {
+        return;
+    }
+
+    task_ref task_copy;
+    {
+        auto tasks = m_impl->tasks->write();
+        if (!tasks->contains(m_impl->handle))
+        {
+            m_impl->started = false;
+            return;
+        }
+        task_copy = tasks->at(m_impl->handle);
+    }
+
+    auto mime_copy    = response.mime;
+    auto headers_copy = response.headers;
+    auto status_copy  = response.status;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        const utils::autorelease_guard guard{};
+
+        auto *const headers = [[[NSMutableDictionary<NSString *, NSString *> alloc] init] autorelease];
+
+        for (const auto &[key, value] : headers_copy)
+        {
+            [headers setObject:[NSString stringWithUTF8String:value.c_str()]
+                        forKey:[NSString stringWithUTF8String:key.c_str()]];
+        }
+
+        auto *const mime = [NSString stringWithUTF8String:mime_copy.c_str()];
+        [headers setObject:mime forKey:@"Content-Type"];
+
+        auto *const res = [[[NSHTTPURLResponse alloc] initWithURL:task_copy.get().request.URL
+                                                       statusCode:status_copy
+                                                      HTTPVersion:nil
+                                                     headerFields:headers] autorelease];
+
+        @try
+        {
+            [task_copy.get() didReceiveResponse:res];
+        }
+        @catch (NSException *)
+        {
+        }
+    });
+}
+
+void stream_writer::write(stash data)
+{
+    if (!m_impl || !m_impl->started || m_impl->finished)
+    {
+        return;
+    }
+
+    task_ref task_copy;
+    {
+        auto tasks = m_impl->tasks->read();
+        if (!tasks->contains(m_impl->handle))
+        {
+            return;
+        }
+        task_copy = tasks->at(m_impl->handle);
+    }
+
+    auto data_copy = std::vector<std::uint8_t>(data.data(), data.data() + data.size());
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        const utils::autorelease_guard guard{};
+
+        auto *const ns_data = [NSData dataWithBytes:data_copy.data()
+                                             length:static_cast<NSInteger>(data_copy.size())];
+
+        @try
+        {
+            [task_copy.get() didReceiveData:ns_data];
+        }
+        @catch (NSException *)
+        {
+        }
+    });
+}
+
+void stream_writer::finish()
+{
+    if (!m_impl || !m_impl->started || m_impl->finished.exchange(true))
+    {
+        return;
+    }
+
+    task_ref task_copy;
+    {
+        auto tasks = m_impl->tasks->write();
+        if (!tasks->contains(m_impl->handle))
+        {
+            return;
+        }
+        task_copy = tasks->at(m_impl->handle);
+        tasks->erase(m_impl->handle);
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        const utils::autorelease_guard guard{};
+
+        @try
+        {
+            [task_copy.get() didFinish];
+        }
+        @catch (NSException *)
+        {
+        }
+    });
+}
+
+void stream_writer::reject(error err)
+{
+    if (!m_impl || m_impl->finished.exchange(true))
+    {
+        return;
+    }
+
+    task_ref task_copy;
+    {
+        auto tasks = m_impl->tasks->write();
+        if (!tasks->contains(m_impl->handle))
+        {
+            return;
+        }
+        task_copy = tasks->at(m_impl->handle);
+        tasks->erase(m_impl->handle);
+    }
+
+    auto err_code = std::to_underlying(err);
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        const utils::autorelease_guard guard{};
+
+        @try
+        {
+            [task_copy.get() didFailWithError:[NSError errorWithDomain:NSURLErrorDomain
+                                                                  code:err_code
+                                                              userInfo:nil]];
+        }
+        @catch (NSException *)
+        {
+        }
+    });
+}
+
+bool stream_writer::valid() const
+{
+    if (!m_impl)
+    {
+        return false;
+    }
+
+    auto tasks = m_impl->tasks->read();
+    return tasks->contains(m_impl->handle) && !m_impl->finished;
+}
 
 @implementation SchemeHandler
 - (void)add_callback:(saucer::scheme::resolver)callback webview:(WKWebView *)instance
@@ -9,15 +182,43 @@ using namespace saucer::scheme;
     m_callbacks.emplace(instance, std::move(callback));
 }
 
+- (void)add_stream_callback:(saucer::scheme::stream_resolver)callback webview:(WKWebView *)instance
+{
+    m_stream_callbacks.emplace(instance, std::move(callback));
+}
+
 - (void)del_callback:(WKWebView *)instance
 {
     m_callbacks.erase(instance);
+    m_stream_callbacks.erase(instance);
 }
 
 - (void)webView:(nonnull WKWebView *)instance startURLSchemeTask:(nonnull id<WKURLSchemeTask>)task
 {
     const utils::autorelease_guard guard{};
 
+    if (self->m_stream_callbacks.contains(instance))
+    {
+        auto ref = task_ref::ref(task);
+
+        auto handle = [&]
+        {
+            auto locked = self->m_tasks.write();
+            return locked->emplace(task.hash, ref).first->first;
+        }();
+
+        auto writer_impl    = std::make_shared<stream_writer::impl>();
+        writer_impl->task   = ref;
+        writer_impl->tasks  = &self->m_tasks;
+        writer_impl->handle = handle;
+
+        auto writer = stream_writer{writer_impl};
+        auto req    = scheme::request{{ref}};
+
+        return self->m_stream_callbacks[instance](std::move(req), std::move(writer));
+    }
+
+    // Regular callback handling
     if (!self->m_callbacks.contains(instance))
     {
         return;

--- a/src/wk.webview.mm
+++ b/src/wk.webview.mm
@@ -359,8 +359,28 @@ namespace saucer
         [native::schemes[name].get() add_callback:std::move(resolver) webview:platform->web_view.get()];
     }
 
+    void impl::handle_stream_scheme(const std::string &name, scheme::stream_resolver &&resolver) // NOLINT(*-function-const)
+    {
+        if (!native::schemes.contains(name))
+        {
+            return;
+        }
+
+        [native::schemes[name].get() add_stream_callback:std::move(resolver) webview:platform->web_view.get()];
+    }
+
     void impl::remove_scheme(const std::string &name) // NOLINT(*-function-const)
     {
+        [native::schemes[name].get() del_callback:platform->web_view.get()];
+    }
+
+    void impl::remove_stream_scheme(const std::string &name) // NOLINT(*-function-const)
+    {
+        if (!native::schemes.contains(name))
+        {
+            return;
+        }
+
         [native::schemes[name].get() del_callback:platform->web_view.get()];
     }
 

--- a/src/wkg.scheme.impl.cpp
+++ b/src/wkg.scheme.impl.cpp
@@ -4,8 +4,148 @@
 
 #include <rebind/utils/enum.hpp>
 
+#include <unistd.h>
+#include <gio/gunixinputstream.h>
+
 namespace saucer::scheme
 {
+    stream_writer::stream_writer(std::shared_ptr<impl> impl) : m_impl(std::move(impl)) {}
+    stream_writer::stream_writer(const stream_writer &) = default;
+    stream_writer::stream_writer(stream_writer &&) noexcept = default;
+    stream_writer::~stream_writer() = default;
+
+    void stream_writer::start(const stream_response &response)
+    {
+        if (!m_impl || m_impl->started.exchange(true) || m_impl->finished)
+        {
+            return;
+        }
+
+        int fds[2];
+        if (pipe(fds) == -1)
+        {
+            m_impl->started = false;
+            return;
+        }
+
+        m_impl->write_fd = fds[1];
+
+        auto stream = utils::g_object_ptr<GInputStream>{g_unix_input_stream_new(fds[0], TRUE)};
+        auto res    = utils::g_object_ptr<WebKitURISchemeResponse>{webkit_uri_scheme_response_new(stream.get(), -1)};
+
+        auto *const headers = soup_message_headers_new(SOUP_MESSAGE_HEADERS_RESPONSE);
+
+        for (const auto &[name, value] : response.headers)
+        {
+            soup_message_headers_append(headers, name.c_str(), value.c_str());
+        }
+
+        webkit_uri_scheme_response_set_content_type(res.get(), response.mime.c_str());
+        webkit_uri_scheme_response_set_status(res.get(), response.status, nullptr);
+        webkit_uri_scheme_response_set_http_headers(res.get(), headers);
+
+        webkit_uri_scheme_request_finish_with_response(m_impl->request.get(), res.get());
+    }
+
+    void stream_writer::write(stash data)
+    {
+        if (!m_impl || !m_impl->started || m_impl->finished || m_impl->write_fd < 0)
+        {
+            return;
+        }
+
+        const auto *ptr       = data.data();
+        std::size_t remaining = data.size();
+
+        while (remaining > 0)
+        {
+            auto written = ::write(m_impl->write_fd, ptr, remaining);
+
+            if (written < 0)
+            {
+                if (errno == EINTR)
+                {
+                    continue;
+                }
+                break;
+            }
+
+            ptr += written;
+            remaining -= static_cast<std::size_t>(written);
+        }
+    }
+
+    void stream_writer::finish()
+    {
+        if (!m_impl || !m_impl->started || m_impl->finished.exchange(true))
+        {
+            return;
+        }
+
+        if (m_impl->write_fd >= 0)
+        {
+            close(m_impl->write_fd);
+            m_impl->write_fd = -1;
+        }
+    }
+
+    void stream_writer::reject(error err)
+    {
+        if (!m_impl || m_impl->finished.exchange(true))
+        {
+            return;
+        }
+
+        if (m_impl->write_fd >= 0)
+        {
+            close(m_impl->write_fd);
+            m_impl->write_fd = -1;
+        }
+
+        if (!m_impl->started)
+        {
+            static auto quark = webkit_network_error_quark();
+            auto value        = std::to_underlying(err);
+            auto name         = std::string{rebind::utils::find_enum_name(err).value_or("unknown")};
+            auto error        = utils::handle<GError *, g_error_free>{g_error_new(quark, value, "%s", name.c_str())};
+
+            webkit_uri_scheme_request_finish_error(m_impl->request.get(), error.get());
+        }
+    }
+
+    bool stream_writer::valid() const
+    {
+        return m_impl && !m_impl->finished;
+    }
+
+    void stream_handler::add_callback(WebKitWebView *id, scheme::stream_resolver callback)
+    {
+        m_callbacks.emplace(id, std::move(callback));
+    }
+
+    void stream_handler::del_callback(WebKitWebView *id)
+    {
+        m_callbacks.erase(id);
+    }
+
+    void stream_handler::handle(WebKitURISchemeRequest *raw, stream_handler *state)
+    {
+        auto request           = utils::g_object_ptr<WebKitURISchemeRequest>::ref(raw);
+        auto *const identifier = webkit_uri_scheme_request_get_web_view(request.get());
+
+        if (!state->m_callbacks.contains(identifier))
+        {
+            return;
+        }
+
+        auto writer_impl     = std::make_shared<stream_writer::impl>();
+        writer_impl->request = request;
+
+        auto writer = stream_writer{writer_impl};
+        auto req    = scheme::request{{request}};
+
+        return state->m_callbacks[identifier](std::move(req), std::move(writer));
+    }
     void handler::add_callback(WebKitWebView *id, scheme::resolver callback)
     {
         m_callbacks.emplace(id, std::move(callback));

--- a/src/wv2.scheme.cpp
+++ b/src/wv2.scheme.cpp
@@ -2,8 +2,199 @@
 
 #include "win32.utils.hpp"
 
+#include <shlwapi.h>
+
 namespace saucer::scheme
 {
+    void stream_buffer::push(const std::uint8_t *data, std::size_t size)
+    {
+        {
+            std::lock_guard lock{m_mutex};
+            m_buffer.insert(m_buffer.end(), data, data + size);
+        }
+        m_cv.notify_one();
+    }
+
+    void stream_buffer::close_write()
+    {
+        {
+            std::lock_guard lock{m_mutex};
+            m_finished = true;
+        }
+        m_cv.notify_one();
+    }
+
+    HRESULT stream_buffer::QueryInterface(REFIID riid, void **ppv)
+    {
+        if (riid == IID_IUnknown || riid == IID_IStream || riid == IID_ISequentialStream)
+        {
+            *ppv = static_cast<IStream *>(this);
+            AddRef();
+            return S_OK;
+        }
+        *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
+
+    ULONG stream_buffer::AddRef() { return InterlockedIncrement(&m_ref); }
+
+    ULONG stream_buffer::Release()
+    {
+        auto ref = InterlockedDecrement(&m_ref);
+        if (ref == 0)
+        {
+            delete this;
+        }
+        return ref;
+    }
+
+    HRESULT stream_buffer::Read(void *pv, ULONG cb, ULONG *pcbRead)
+    {
+        std::unique_lock lock{m_mutex};
+        m_cv.wait(lock, [this] { return !m_buffer.empty() || m_finished; });
+
+        if (m_buffer.empty())
+        {
+            if (pcbRead)
+            {
+                *pcbRead = 0;
+            }
+            return m_finished ? S_FALSE : S_OK;
+        }
+
+        auto to_read = std::min(static_cast<std::size_t>(cb), m_buffer.size());
+        std::copy_n(m_buffer.begin(), to_read, static_cast<std::uint8_t *>(pv));
+        m_buffer.erase(m_buffer.begin(), m_buffer.begin() + static_cast<std::ptrdiff_t>(to_read));
+
+        if (pcbRead)
+        {
+            *pcbRead = static_cast<ULONG>(to_read);
+        }
+        return S_OK;
+    }
+
+    HRESULT stream_buffer::Write(const void *, ULONG, ULONG *) { return E_NOTIMPL; }
+    HRESULT stream_buffer::Seek(LARGE_INTEGER, DWORD, ULARGE_INTEGER *) { return E_NOTIMPL; }
+    HRESULT stream_buffer::SetSize(ULARGE_INTEGER) { return E_NOTIMPL; }
+    HRESULT stream_buffer::CopyTo(IStream *, ULARGE_INTEGER, ULARGE_INTEGER *, ULARGE_INTEGER *) { return E_NOTIMPL; }
+    HRESULT stream_buffer::Commit(DWORD) { return E_NOTIMPL; }
+    HRESULT stream_buffer::Revert() { return E_NOTIMPL; }
+    HRESULT stream_buffer::LockRegion(ULARGE_INTEGER, ULARGE_INTEGER, DWORD) { return E_NOTIMPL; }
+    HRESULT stream_buffer::UnlockRegion(ULARGE_INTEGER, ULARGE_INTEGER, DWORD) { return E_NOTIMPL; }
+
+    HRESULT stream_buffer::Stat(STATSTG *pstatstg, DWORD)
+    {
+        if (!pstatstg)
+        {
+            return E_POINTER;
+        }
+        std::memset(pstatstg, 0, sizeof(*pstatstg));
+        pstatstg->type = STGTY_STREAM;
+        return S_OK;
+    }
+
+    HRESULT stream_buffer::Clone(IStream **) { return E_NOTIMPL; }
+
+    stream_writer::stream_writer(std::shared_ptr<impl> impl) : m_impl(std::move(impl)) {}
+    stream_writer::stream_writer(const stream_writer &) = default;
+    stream_writer::stream_writer(stream_writer &&) noexcept = default;
+    stream_writer::~stream_writer() = default;
+
+    void stream_writer::start(const stream_response &response)
+    {
+        if (!m_impl || m_impl->started.exchange(true) || m_impl->finished)
+        {
+            return;
+        }
+
+        std::vector<std::wstring> headers = {std::format(L"Content-Type: {}", utils::widen(response.mime))};
+
+        for (const auto &[name, value] : response.headers)
+        {
+            headers.emplace_back(std::format(L"{}: {}", utils::widen(name), utils::widen(value)));
+        }
+
+        std::wstring combined;
+        for (std::size_t i = 0; i < headers.size(); ++i)
+        {
+            if (i > 0)
+            {
+                combined += L"\r\n";
+            }
+            combined += headers[i];
+        }
+
+        ComPtr<ICoreWebView2WebResourceResponse> result;
+        m_impl->environment->CreateWebResourceResponse(m_impl->buffer, response.status, L"OK", combined.c_str(), &result);
+
+        m_impl->args->put_Response(result.Get());
+        m_impl->deferral->Complete();
+    }
+
+    void stream_writer::write(stash data)
+    {
+        if (!m_impl || !m_impl->started || m_impl->finished)
+        {
+            return;
+        }
+
+        m_impl->buffer->push(data.data(), data.size());
+    }
+
+    void stream_writer::finish()
+    {
+        if (!m_impl || !m_impl->started || m_impl->finished.exchange(true))
+        {
+            return;
+        }
+
+        m_impl->buffer->close_write();
+    }
+
+    void stream_writer::reject(error err)
+    {
+        if (!m_impl || m_impl->finished.exchange(true))
+        {
+            return;
+        }
+
+        if (m_impl->started)
+        {
+            m_impl->buffer->close_write();
+            return;
+        }
+
+        auto status = std::to_underlying(err);
+        std::wstring phrase;
+
+        switch (err)
+        {
+            using enum scheme::error;
+
+        case not_found:
+            phrase = L"Not Found";
+            break;
+        case invalid:
+            phrase = L"Bad Request";
+            break;
+        case denied:
+            phrase = L"Unauthorized";
+            break;
+        default:
+            break;
+        }
+
+        ComPtr<ICoreWebView2WebResourceResponse> result;
+        m_impl->environment->CreateWebResourceResponse(nullptr, status, L"", phrase.c_str(), &result);
+
+        m_impl->args->put_Response(result.Get());
+        m_impl->deferral->Complete();
+    }
+
+    bool stream_writer::valid() const
+    {
+        return m_impl && !m_impl->finished;
+    }
     request::request(impl data) : m_impl(std::make_unique<impl>(std::move(data))) {}
 
     request::request(const request &other) : request(*other.m_impl) {}

--- a/src/wv2.webview.cpp
+++ b/src/wv2.webview.cpp
@@ -461,6 +461,21 @@ namespace saucer
                                                                                 COREWEBVIEW2_WEB_RESOURCE_REQUEST_SOURCE_KINDS_ALL);
     }
 
+    void impl::handle_stream_scheme(const std::string &name, scheme::stream_resolver &&resolver) // NOLINT(*-function-const)
+    {
+        if (platform->stream_schemes.contains(name))
+        {
+            return;
+        }
+
+        platform->stream_schemes.emplace(name, std::move(resolver));
+
+        const auto pattern = utils::widen(std::format("{}*", name));
+
+        platform->web_view->AddWebResourceRequestedFilterWithRequestSourceKinds(pattern.c_str(), COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL,
+                                                                                COREWEBVIEW2_WEB_RESOURCE_REQUEST_SOURCE_KINDS_ALL);
+    }
+
     void impl::remove_scheme(const std::string &name) // NOLINT(*-function-const)
     {
         auto it = platform->schemes.find(name);
@@ -476,6 +491,23 @@ namespace saucer
                                                                                    COREWEBVIEW2_WEB_RESOURCE_REQUEST_SOURCE_KINDS_ALL);
 
         platform->schemes.erase(it);
+    }
+
+    void impl::remove_stream_scheme(const std::string &name) // NOLINT(*-function-const)
+    {
+        auto it = platform->stream_schemes.find(name);
+
+        if (it == platform->stream_schemes.end())
+        {
+            return;
+        }
+
+        const auto pattern = utils::widen(std::format("{}*", name));
+
+        platform->web_view->RemoveWebResourceRequestedFilterWithRequestSourceKinds(pattern.c_str(), COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL,
+                                                                                   COREWEBVIEW2_WEB_RESOURCE_REQUEST_SOURCE_KINDS_ALL);
+
+        platform->stream_schemes.erase(it);
     }
 
     void impl::register_scheme(const std::string &name)


### PR DESCRIPTION
Add stream_writer class and handle_stream_scheme() for streaming responses.

- WebKit (macOS): Uses WKURLSchemeTask streaming API
- Qt: Custom QIODevice with thread-safe buffer
- WebKitGTK: Unix pipes for streaming
- WebView2: Custom IStream with thread-safe buffer

This enables Server-Side-Events over the custom scheme and theoretically other streaming response types like WebSockets.

Related: #67
Conversation: https://discord.com/channels/924655908292800573/924658162236272652/1465955713355354215