### PR TITLE
Introduce Load Failed Event

### DIFF
--- a/include/saucer/webview.hpp
+++ b/include/saucer/webview.hpp
@@ -40,6 +40,7 @@ namespace saucer
     {
         started,
         finished,
+        failed,
     };
 
     enum class status : std::uint8_t

--- a/private/saucer/wkg.webview.impl.hpp
+++ b/private/saucer/wkg.webview.impl.hpp
@@ -43,6 +43,7 @@ namespace saucer
       public:
         std::size_t id_context;
         std::size_t id_load;
+        std::size_t id_error;
 
       public:
         std::size_t id_message;
@@ -61,6 +62,7 @@ namespace saucer
       public:
         static void on_message(WebKitWebView *, JSCValue *, impl *);
         static void on_load(WebKitWebView *, WebKitLoadEvent, impl *);
+        static void on_error(WebKitWebView *, WebKitLoadEvent, gchar *, GError *, impl *);
 
       public:
         static void on_click(GtkGestureClick *, gint, gdouble, gdouble, impl *);

--- a/private/saucer/wv2.webview.impl.hpp
+++ b/private/saucer/wv2.webview.impl.hpp
@@ -67,6 +67,7 @@ namespace saucer
       public:
         bool dom_loaded{false};
         std::vector<std::string> pending;
+        std::optional<uint64_t> navigation_id;
 
       public:
         std::size_t id_counter{0};

--- a/src/qt.webview.impl.cpp
+++ b/src/qt.webview.impl.cpp
@@ -214,9 +214,9 @@ namespace saucer
             return;
         }
 
-        auto handler = [self](auto...)
+        auto handler = [self](const bool ok)
         {
-            self->events.get<event::load>().fire(state::finished);
+            self->events.get<event::load>().fire(ok ? state::finished : state::failed);
         };
 
         const auto id = web_view->connect(web_view.get(), &QWebEngineView::loadFinished, handler);

--- a/src/wk.webview.impl.mm
+++ b/src/wk.webview.impl.mm
@@ -378,6 +378,12 @@ using namespace saucer;
 {
     me->events.get<event::load>().fire(state::finished);
 }
+
+- (void)webView:(WKWebView *)webview didFail:(WKNavigation *)navigation withError:(WKError)error
+{
+    me->events.get<event::load>().fire(state::failed);
+}
+
 @end
 
 @implementation SaucerView

--- a/src/wkg.webview.cpp
+++ b/src/wkg.webview.cpp
@@ -50,6 +50,7 @@ namespace saucer
 
         platform->id_context = utils::connect(platform->web_view, "context-menu", native::on_context, this);
         platform->id_load    = utils::connect(platform->web_view, "load-changed", native::on_load, this);
+        platform->id_error   = utils::connect(platform->web_view, "load-error", native::on_error, this);
 
         // The ContentManager is ref'd to prevent it from being destroyed early when using multiple webviews
         platform->manager = content_manager_ptr::ref(webkit_web_view_get_user_content_manager(platform->web_view));

--- a/src/wkg.webview.impl.cpp
+++ b/src/wkg.webview.impl.cpp
@@ -319,6 +319,11 @@ namespace saucer
         self->events.get<event::load>().fire(state::started);
     }
 
+    void native::on_error(WebKitWebView *, WebKitLoadEvent, gchar *, GError *, impl *)
+    {
+        self->events.get<event::load>().fire(state::failed);
+    }
+
     void native::on_click(GtkGestureClick *gesture, gint, gdouble, gdouble, impl *self)
     {
         auto *const controller = GTK_EVENT_CONTROLLER(gesture);

--- a/src/wv2.webview.impl.cpp
+++ b/src/wv2.webview.impl.cpp
@@ -160,14 +160,27 @@ namespace saucer
             return;
         }
 
-        static constexpr auto fire = [](impl *self)
+        static constexpr auto fire = [](state state, impl *self)
         {
-            self->events.get<event::load>().fire(state::finished);
+            self->events.get<event::load>().fire(state);
         };
 
-        auto handler = [self](auto...)
+        auto handler = [self](ICoreWebView2 *, ICoreWebView2NavigationCompletedEventArgs *args)
         {
-            self->parent->post(utils::defer(self->platform->lease, fire));
+            UINT64 navigation_id;
+            args->get_NavigationId(&navigation_id);
+
+            if (self->platform->navigation_id.has_value() && self->platform->navigation_id.value() == navigation_id)
+            {
+                BOOL success;
+                args->get_IsSuccess(&success);
+
+                state state = success ? state::finished : state::failed;
+                self->parent->post(utils::defer(self->platform->lease, std::bind_front(fire, state)));
+
+                self->platform->navigation_id.reset();
+            }
+
             return S_OK;
         };
 
@@ -326,11 +339,20 @@ namespace saucer
 
     HRESULT native::on_navigation(impl *self, ICoreWebView2 *, ICoreWebView2NavigationStartingEventArgs *args)
     {
+        if (self->platform->navigation_id.has_value())
+        {
+            return S_OK;
+        }
+
         static constexpr auto fire = [](impl *self)
         {
             self->events.get<event::load>().fire(state::started);
         };
 
+        UINT64 navigation_id;
+        args->get_NavigationId(&navigation_id);
+
+        self->platform->navigation_id = navigation_id;
         self->platform->dom_loaded = false;
         self->parent->post(utils::defer(self->platform->lease, fire));
 


### PR DESCRIPTION
Hello, maybe I missed something, but I didn't see any events to catch load failure, e.g. if the target website is down. We would like to add a fallback in this case. I've added a new load state (failed) and implemented it for all platforms. Please note that I wasn't able to test on linux, mac and Qt, as I don't have any environment setup for testing these yet, but I did dig into each API to figure how to implement this.

Let me know if you have questions, or if there's a better way to do it.

Thanks!