### PR TITLE
update glaze to 7.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,7 @@ saucer_include_directories(${PROJECT_NAME} "private")
 # +-------------------------------------------------------------------------------------------------------+
 
 if (saucer_serializer STREQUAL "Glaze")
-  set(SERIALIZER_DEP "glaze 6.4.0")
+  set(SERIALIZER_DEP "glaze 7.2.0")
 endif()
 
 if (saucer_serializer STREQUAL "Rflpp")

--- a/src/glaze.serializer.cpp
+++ b/src/glaze.serializer.cpp
@@ -28,10 +28,15 @@ struct glz::meta<saucer::serializers::glaze::result_data>
 
 namespace saucer::serializers::glaze
 {
-    static constexpr auto opts = glz::opts{
-        .error_on_unknown_keys = true,
-        .error_on_missing_keys = true,
-        .raw_string            = false,
+    struct raw_string_opts : glz::opts {
+        bool raw_string = true;
+    };
+    static constexpr auto opts = raw_string_opts{
+        glz::opts{
+            .error_on_unknown_keys = true,
+            .error_on_missing_keys = true,
+        },
+        false // raw_string
     };
 
     serializer::~serializer() = default;


### PR DESCRIPTION
This PR is for updating glaze to the latest version, 7.2.0.

Glaze removed the raw_string member from glz::opts in 7.0.0. 
https://github.com/stephenberry/glaze/releases/tag/v7.0.0

we need to create a struct that inherits glz::opts.
