### PR TITLE
Make Adwaita "Optional"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(saucer_exceptions       "Enable exception support (Respects -fno-exceptio
 option(saucer_examples         "Build examples"                                                      OFF)
 option(saucer_tests            "Build tests"                                                         OFF)
 
+option(saucer_adwaita          "Use LibAdwaita when using the WebKitGtk backend"                      ON)
 option(saucer_msvc_hack        "Fix mutex crash on mismatching runtimes. See VS2022 17.10 changelog" OFF)
 option(saucer_unexpected_hack  "Fix std::unexpected ambiguity issues when compiling with zig"        OFF)
 option(saucer_private_webkit   "Enable private api usage for wkwebview"                               ON)
@@ -172,6 +173,10 @@ endif()
 
 if (NOT saucer_exceptions)
   target_compile_definitions(${PROJECT_NAME} PUBLIC SAUCER_NO_EXCEPTIONS)
+endif()
+
+if (saucer_adwaita)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC SAUCER_ADWAITA)
 endif()
 
 if (saucer_msvc_hack)

--- a/include/saucer/modules/stable/webkitgtk.hpp
+++ b/include/saucer/modules/stable/webkitgtk.hpp
@@ -6,7 +6,7 @@
 #include <saucer/window.hpp>
 #include <saucer/webview.hpp>
 
-#include <adwaita.h>
+#include <gtk/gtk.h>
 #include <webkit/webkit.h>
 
 namespace saucer
@@ -14,7 +14,7 @@ namespace saucer
     template <>
     struct stable_natives<application>
     {
-        AdwApplication *application;
+        GtkApplication *application;
     };
 
     template <>

--- a/private/saucer/gtk.app.impl.hpp
+++ b/private/saucer/gtk.app.impl.hpp
@@ -5,13 +5,13 @@
 
 #include <unordered_map>
 
-#include <adwaita.h>
+#include <gtk/gtk.h>
 
 namespace saucer
 {
     struct application::impl::native
     {
-        utils::g_object_ptr<AdwApplication> application;
+        utils::g_object_ptr<GtkApplication> application;
 
       public:
         int argc;

--- a/private/saucer/gtk.utils.hpp
+++ b/private/saucer/gtk.utils.hpp
@@ -9,13 +9,19 @@
 
 namespace saucer::utils
 {
+    template <typename T>
+    void widget_unref(T *);
+
     using g_str_ptr   = handle<gchar *, g_free>;
     using g_error_ptr = handle<GError *, g_error_free>;
+    using g_bytes_ptr = ref_ptr<GBytes, g_bytes_ref, g_bytes_unref>;
+    using g_event_ptr = ref_ptr<GdkEvent, gdk_event_ref, gdk_event_unref>;
 
     template <typename T>
     using g_object_ptr = ref_ptr<T, g_object_ref, g_object_unref>;
-    using g_bytes_ptr  = ref_ptr<GBytes, g_bytes_ref, g_bytes_unref>;
-    using g_event_ptr  = ref_ptr<GdkEvent, gdk_event_ref, gdk_event_unref>;
+
+    template <typename T>
+    using g_widget_ptr = ref_ptr<T, g_object_ref, widget_unref<T>>;
 
     template <typename T, typename R, typename... Ts, typename Data>
         requires std::same_as<tuple::last_t<std::tuple<Ts...>>, Data *>

--- a/private/saucer/gtk.utils.inl
+++ b/private/saucer/gtk.utils.inl
@@ -4,6 +4,19 @@
 
 namespace saucer
 {
+    template <typename T>
+    void utils::widget_unref(T *ptr)
+    {
+        auto *const widget = GTK_WIDGET(ptr);
+
+        if (gtk_widget_get_parent(widget))
+        {
+            return;
+        }
+
+        g_object_unref(ptr);
+    }
+
     template <typename T, typename R, typename... Ts, typename Data>
         requires std::same_as<tuple::last_t<std::tuple<Ts...>>, Data *>
     auto utils::connect(T *instance, const char *name, R (*callback)(Ts...), Data *data)

--- a/private/saucer/gtk.window.impl.hpp
+++ b/private/saucer/gtk.window.impl.hpp
@@ -85,4 +85,8 @@ namespace saucer
         void update_region(impl *) const;
         void update_decorations(impl *) const;
     };
+
+    struct SaucerWindow;
+
+    SaucerWindow *saucer_window_new(GtkApplication *, window::impl *);
 } // namespace saucer

--- a/private/saucer/gtk.window.impl.hpp
+++ b/private/saucer/gtk.window.impl.hpp
@@ -51,11 +51,11 @@ namespace saucer
         std::optional<decoration> prev_decoration;
 
       public:
-        GtkWidget *header;
-        GtkOverlay *content;
+        utils::g_widget_ptr<GtkWidget> header;
+        utils::g_widget_ptr<GtkOverlay> content;
 
       public:
-        GtkEventController *motion_controller;
+        utils::g_widget_ptr<GtkEventController> motion_controller;
         utils::handle<cairo_region_t *, cairo_region_destroy> region;
 
       public:

--- a/private/saucer/gtk.window.impl.hpp
+++ b/private/saucer/gtk.window.impl.hpp
@@ -8,7 +8,7 @@
 
 #include <optional>
 
-#include <adwaita.h>
+#include <gtk/gtk.h>
 
 namespace saucer
 {
@@ -51,8 +51,8 @@ namespace saucer
         std::optional<decoration> prev_decoration;
 
       public:
+        GtkWidget *header;
         GtkOverlay *content;
-        AdwHeaderBar *header;
 
       public:
         GtkEventController *motion_controller;

--- a/src/gtk.app.cpp
+++ b/src/gtk.app.cpp
@@ -2,6 +2,10 @@
 
 #include <format>
 
+#ifdef SAUCER_ADWAITA
+#include <adwaita.h>
+#endif
+
 namespace saucer
 {
     using impl = application::impl;
@@ -19,7 +23,11 @@ namespace saucer
             id = std::format("app.saucer.{}", native::fix_id(id));
         }
 
-        platform->application = adw_application_new(id.c_str(), G_APPLICATION_DEFAULT_FLAGS);
+#ifdef SAUCER_ADWAITA
+        platform->application = GTK_APPLICATION(adw_application_new(id.c_str(), G_APPLICATION_DEFAULT_FLAGS));
+#else
+        platform->application = gtk_application_new(id.c_str(), G_APPLICATION_DEFAULT_FLAGS);
+#endif
 
         platform->argc                       = opts.argc.value_or(0);
         platform->argv                       = opts.argv.value_or(nullptr);

--- a/src/gtk.window.cpp
+++ b/src/gtk.window.cpp
@@ -31,13 +31,13 @@ namespace saucer
 #endif
 
         auto *const box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-        gtk_box_append(box, GTK_WIDGET(platform->content));
+        gtk_box_append(box, GTK_WIDGET(platform->content.get()));
 
-        gtk_widget_set_vexpand(GTK_WIDGET(platform->content), true);
-        gtk_widget_set_hexpand(GTK_WIDGET(platform->content), true);
+        gtk_widget_set_vexpand(GTK_WIDGET(platform->content.get()), true);
+        gtk_widget_set_hexpand(GTK_WIDGET(platform->content.get()), true);
 
 #ifdef SAUCER_ADWAITA
-        gtk_box_prepend(box, platform->header);
+        gtk_box_prepend(box, platform->header.get());
         adw_application_window_set_content(ADW_APPLICATION_WINDOW(platform->window.get()), GTK_WIDGET(box));
 #else
         gtk_window_set_child(GTK_WINDOW(platform->window.get()), GTK_WIDGET(box));
@@ -121,7 +121,7 @@ namespace saucer
 
     bool impl::click_through() const
     {
-        return platform->motion_controller;
+        return platform->motion_controller.get();
     }
 
     std::string impl::title() const
@@ -143,7 +143,7 @@ namespace saucer
             return none;
         }
 
-        if (!gtk_widget_get_visible(GTK_WIDGET(platform->header)))
+        if (!gtk_widget_get_visible(GTK_WIDGET(platform->header.get())))
         {
             return partial;
         }
@@ -295,7 +295,7 @@ namespace saucer
         }
 
         auto *const widget = GTK_WIDGET(platform->window.get());
-        gtk_widget_remove_controller(widget, platform->motion_controller);
+        gtk_widget_remove_controller(widget, platform->motion_controller.get());
 
         platform->motion_controller = nullptr;
         platform->region.reset();
@@ -330,7 +330,7 @@ namespace saucer
 #endif
 
         gtk_window_set_decorated(platform->window.get(), decorated);
-        gtk_widget_set_visible(GTK_WIDGET(platform->header), visible);
+        gtk_widget_set_visible(GTK_WIDGET(platform->header.get()), visible);
     }
 
     void impl::set_size(saucer::size size) // NOLINT(*-function-const)

--- a/src/gtk.window.cpp
+++ b/src/gtk.window.cpp
@@ -28,6 +28,7 @@ namespace saucer
         platform->header = GTK_WIDGET(adw_header_bar_new());
 #else
         platform->header = GTK_WIDGET(gtk_header_bar_new());
+        g_object_ref_sink(platform->header.get()); // We will only use this when needed, let's not keep it potentially floating
 #endif
 
         auto *const box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
@@ -41,7 +42,7 @@ namespace saucer
         adw_application_window_set_content(ADW_APPLICATION_WINDOW(platform->window.get()), GTK_WIDGET(box));
 #else
         gtk_window_set_child(GTK_WINDOW(platform->window.get()), GTK_WIDGET(box));
-        gtk_css_provider_load_from_string(platform->style.get(), "webview { border-radius: 0; }");
+        gtk_css_provider_load_from_string(platform->style.get(), "window.background { border-radius: 0; }");
 #endif
 
         gtk_window_set_hide_on_close(platform->window.get(), true);
@@ -326,7 +327,7 @@ namespace saucer
         const auto visible   = decoration == decoration::full;
 
 #ifndef SAUCER_ADWAITA
-        gtk_window_set_titlebar(platform->window.get(), visible ? nullptr : platform->header);
+        gtk_window_set_titlebar(platform->window.get(), visible ? nullptr : platform->header.get());
 #endif
 
         gtk_window_set_decorated(platform->window.get(), decorated);

--- a/src/gtk.window.cpp
+++ b/src/gtk.window.cpp
@@ -18,18 +18,17 @@ namespace saucer
         platform = std::make_unique<native>();
 
         auto *const application = GTK_APPLICATION(parent->native<false>()->platform->application.get());
-
-#ifdef SAUCER_ADWAITA
-        platform->window.reset(GTK_WINDOW(adw_application_window_new(application)));
-        platform->header = GTK_WIDGET(adw_header_bar_new());
-#else
-        platform->window.reset(GTK_WINDOW(gtk_application_window_new(application)));
-        platform->header = GTK_WIDGET(gtk_header_bar_new());
-#endif
+        platform->window.reset(GTK_WINDOW(saucer_window_new(application, this)));
 
         platform->style   = gtk_css_provider_new();
         platform->content = GTK_OVERLAY(gtk_overlay_new());
         platform->lease   = utils::lease{this};
+
+#ifdef SAUCER_ADWAITA
+        platform->header = GTK_WIDGET(adw_header_bar_new());
+#else
+        platform->header = GTK_WIDGET(gtk_header_bar_new());
+#endif
 
         auto *const box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
         gtk_box_append(box, GTK_WIDGET(platform->content));
@@ -154,8 +153,8 @@ namespace saucer
 
     size impl::size() const
     {
-        int width{}, height{};
-        gtk_window_get_default_size(platform->window.get(), &width, &height);
+        auto width  = gtk_widget_get_size(GTK_WIDGET(platform->window.get()), GTK_ORIENTATION_HORIZONTAL);
+        auto height = gtk_widget_get_size(GTK_WIDGET(platform->window.get()), GTK_ORIENTATION_VERTICAL);
 
         return platform->offset<offset::sub>({.w = width, .h = height});
     }

--- a/src/gtk.window.cpp
+++ b/src/gtk.window.cpp
@@ -3,6 +3,10 @@
 #include "instantiate.hpp"
 #include "gtk.app.impl.hpp"
 
+#ifdef SAUCER_ADWAITA
+#include <adwaita.h>
+#endif
+
 namespace saucer
 {
     using impl = window::impl;
@@ -14,24 +18,32 @@ namespace saucer
         platform = std::make_unique<native>();
 
         auto *const application = GTK_APPLICATION(parent->native<false>()->platform->application.get());
+
+#ifdef SAUCER_ADWAITA
         platform->window.reset(GTK_WINDOW(adw_application_window_new(application)));
+        platform->header = GTK_WIDGET(adw_header_bar_new());
+#else
+        platform->window.reset(GTK_WINDOW(gtk_application_window_new(application)));
+        platform->header = GTK_WIDGET(gtk_header_bar_new());
+#endif
 
         platform->style   = gtk_css_provider_new();
-        platform->header  = ADW_HEADER_BAR(adw_header_bar_new());
         platform->content = GTK_OVERLAY(gtk_overlay_new());
         platform->lease   = utils::lease{this};
 
         auto *const box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-        auto *const bin = ADW_BIN(adw_bin_new());
-
-        gtk_box_append(box, GTK_WIDGET(platform->header));
         gtk_box_append(box, GTK_WIDGET(platform->content));
 
-        gtk_widget_set_vexpand(GTK_WIDGET(bin), true);
-        gtk_widget_set_hexpand(GTK_WIDGET(bin), true);
+        gtk_widget_set_vexpand(GTK_WIDGET(platform->content), true);
+        gtk_widget_set_hexpand(GTK_WIDGET(platform->content), true);
 
-        gtk_overlay_set_child(platform->content, GTK_WIDGET(bin));
+#ifdef SAUCER_ADWAITA
+        gtk_box_prepend(box, platform->header);
         adw_application_window_set_content(ADW_APPLICATION_WINDOW(platform->window.get()), GTK_WIDGET(box));
+#else
+        gtk_window_set_child(GTK_WINDOW(platform->window.get()), GTK_WIDGET(box));
+        gtk_css_provider_load_from_string(platform->style.get(), "webview { border-radius: 0; }");
+#endif
 
         gtk_window_set_hide_on_close(platform->window.get(), true);
 
@@ -313,6 +325,10 @@ namespace saucer
     {
         const auto decorated = decoration != decoration::none;
         const auto visible   = decoration == decoration::full;
+
+#ifndef SAUCER_ADWAITA
+        gtk_window_set_titlebar(platform->window.get(), visible ? nullptr : platform->header);
+#endif
 
         gtk_window_set_decorated(platform->window.get(), decorated);
         gtk_widget_set_visible(GTK_WIDGET(platform->header), visible);

--- a/src/gtk.window.impl.cpp
+++ b/src/gtk.window.impl.cpp
@@ -191,12 +191,12 @@ namespace saucer
 
     void native::add_widget(GtkWidget *widget) const
     {
-        gtk_overlay_add_overlay(content, widget);
+        gtk_overlay_add_overlay(content.get(), widget);
     }
 
     void native::remove_widget(GtkWidget *widget) const
     {
-        gtk_overlay_remove_overlay(content, widget);
+        gtk_overlay_remove_overlay(content.get(), widget);
     }
 
     void native::track(impl *self) const
@@ -294,8 +294,8 @@ namespace saucer
             gdk_surface_set_input_region(surface, self->platform->region.get());
         };
 
-        utils::connect(motion_controller, "motion", +callback, self);
-        gtk_widget_add_controller(GTK_WIDGET(self->platform->window.get()), motion_controller);
+        utils::connect(motion_controller.get(), "motion", +callback, self);
+        gtk_widget_add_controller(GTK_WIDGET(self->platform->window.get()), motion_controller.get());
     }
 
     void native::update_decorations(impl *self) const
@@ -316,10 +316,10 @@ namespace saucer
 
         auto fullscreen = [](void *, GParamSpec *, impl *self)
         {
-            gtk_widget_set_visible(GTK_WIDGET(self->platform->header), !self->fullscreen());
+            gtk_widget_set_visible(GTK_WIDGET(self->platform->header.get()), !self->fullscreen());
         };
 
-        utils::connect(header, "notify::visible", +decorated, self);
+        utils::connect(header.get(), "notify::visible", +decorated, self);
         utils::connect(window.get(), "notify::decorated", +decorated, self);
         utils::connect(window.get(), "notify::fullscreened", +fullscreen, self);
     }

--- a/src/gtk.window.impl.cpp
+++ b/src/gtk.window.impl.cpp
@@ -13,13 +13,19 @@ namespace saucer
     using native = window::impl::native;
     using event  = window::event;
 
+#ifdef SAUCER_ADWAITA
+    using application_window               = AdwApplicationWindow;
+    using application_window_class         = AdwApplicationWindowClass;
+    static const auto application_window_t = ADW_TYPE_APPLICATION_WINDOW;
+#else
+    using application_window               = GtkApplicationWindow;
+    using application_window_class         = GtkApplicationWindowClass;
+    static const auto application_window_t = GTK_TYPE_APPLICATION_WINDOW;
+#endif
+
     struct SaucerWindow
     {
-#ifdef SAUCER_ADWAITA
-        AdwApplicationWindow parent_instance;
-#else
-        GtkApplicationWindow parent_instance;
-#endif
+        application_window parent_instance;
 
       public:
         window::impl *self;
@@ -27,18 +33,10 @@ namespace saucer
 
     struct SaucerWindowClass
     {
-#ifdef SAUCER_ADWAITA
-        AdwApplicationWindowClass parent_class;
-#else
-        GtkApplicationWindowClass parent_class;
-#endif
+        application_window_class parent_class;
     };
 
-#ifdef SAUCER_ADWAITA
-    G_DEFINE_TYPE(SaucerWindow, saucer_window, ADW_TYPE_APPLICATION_WINDOW);
-#else
-    G_DEFINE_TYPE(SaucerWindow, saucer_window, GTK_TYPE_APPLICATION_WINDOW);
-#endif
+    G_DEFINE_TYPE(SaucerWindow, saucer_window, application_window_t);
 
     void saucer_window_resize(GtkWidget *widget, int width, int height, int baseline)
     {
@@ -160,12 +158,9 @@ namespace saucer
     template <offset T>
     saucer::size native::offset(saucer::size size) const
     {
-#ifndef SAUCER_ADWAITA
-        return size;
-#else
-        auto *const widget = GTK_WIDGET(header);
+        auto *const widget = GTK_WIDGET(header.get());
 
-        if (!gtk_widget_is_visible(widget))
+        if (!gtk_widget_get_parent(widget))
         {
             return size;
         }
@@ -183,7 +178,6 @@ namespace saucer
         }
 
         return size;
-#endif
     }
 
     template saucer::size native::offset<offset::add>(saucer::size) const;

--- a/src/gtk.window.impl.cpp
+++ b/src/gtk.window.impl.cpp
@@ -160,7 +160,7 @@ namespace saucer
     {
         auto *const widget = GTK_WIDGET(header.get());
 
-        if (!gtk_widget_get_parent(widget))
+        if (!!gtk_widget_is_visible(widget) || !gtk_widget_get_parent(widget))
         {
             return size;
         }

--- a/src/gtk.window.impl.cpp
+++ b/src/gtk.window.impl.cpp
@@ -160,7 +160,7 @@ namespace saucer
     {
         auto *const widget = GTK_WIDGET(header.get());
 
-        if (!!gtk_widget_is_visible(widget) || !gtk_widget_get_parent(widget))
+        if (!gtk_widget_is_visible(widget) || !gtk_widget_get_parent(widget))
         {
             return size;
         }

--- a/src/gtk.window.impl.cpp
+++ b/src/gtk.window.impl.cpp
@@ -4,10 +4,66 @@
 
 #include <algorithm>
 
+#ifdef SAUCER_ADWAITA
+#include <adwaita.h>
+#endif
+
 namespace saucer
 {
     using native = window::impl::native;
     using event  = window::event;
+
+    struct SaucerWindow
+    {
+#ifdef SAUCER_ADWAITA
+        AdwApplicationWindow parent_instance;
+#else
+        GtkApplicationWindow parent_instance;
+#endif
+
+      public:
+        window::impl *self;
+    };
+
+    struct SaucerWindowClass
+    {
+#ifdef SAUCER_ADWAITA
+        AdwApplicationWindowClass parent_class;
+#else
+        GtkApplicationWindowClass parent_class;
+#endif
+    };
+
+#ifdef SAUCER_ADWAITA
+    G_DEFINE_TYPE(SaucerWindow, saucer_window, ADW_TYPE_APPLICATION_WINDOW);
+#else
+    G_DEFINE_TYPE(SaucerWindow, saucer_window, GTK_TYPE_APPLICATION_WINDOW);
+#endif
+
+    void saucer_window_resize(GtkWidget *widget, int width, int height, int baseline)
+    {
+        GTK_WIDGET_CLASS(saucer_window_parent_class)->size_allocate(widget, width, height, baseline);
+        auto *const self = reinterpret_cast<SaucerWindow *>(widget)->self;
+        self->events.get<event::resize>().fire(width, height);
+    }
+
+    void saucer_window_class_init(SaucerWindowClass *klass)
+    {
+        auto *widget          = GTK_WIDGET_CLASS(klass);
+        widget->size_allocate = saucer_window_resize;
+    }
+
+    void saucer_window_init(SaucerWindow *)
+    {
+        // Boilerplate
+    }
+
+    SaucerWindow *saucer_window_new(GtkApplication *application, window::impl *self)
+    {
+        auto *const rtn = reinterpret_cast<SaucerWindow *>(g_object_new(saucer_window_get_type(), "application", application, NULL));
+        rtn->self       = self;
+        return rtn;
+    }
 
     std::optional<event_data> native::prev_data() const
     {
@@ -44,30 +100,8 @@ namespace saucer
     }
 
     template <>
-    void native::setup<event::resize>(impl *self)
+    void native::setup<event::resize>(impl *)
     {
-        auto &event = self->events.get<event::resize>();
-
-        if (!event.empty())
-        {
-            return;
-        }
-
-        auto callback = [](void *, GParamSpec *, impl *self)
-        {
-            auto [width, height] = self->size();
-            self->events.get<event::resize>().fire(width, height);
-        };
-
-        const auto width  = utils::connect(window.get(), "notify::default-width", +callback, self);
-        const auto height = utils::connect(window.get(), "notify::default-height", +callback, self);
-
-        event.on_clear(
-            [this, width, height]
-            {
-                g_signal_handler_disconnect(window.get(), width);
-                g_signal_handler_disconnect(window.get(), height);
-            });
     }
 
     template <>

--- a/src/gtk.window.impl.cpp
+++ b/src/gtk.window.impl.cpp
@@ -126,6 +126,9 @@ namespace saucer
     template <offset T>
     saucer::size native::offset(saucer::size size) const
     {
+#ifndef SAUCER_ADWAITA
+        return size;
+#else
         auto *const widget = GTK_WIDGET(header);
 
         if (!gtk_widget_is_visible(widget))
@@ -146,6 +149,7 @@ namespace saucer
         }
 
         return size;
+#endif
     }
 
     template saucer::size native::offset<offset::add>(saucer::size) const;
@@ -267,7 +271,7 @@ namespace saucer
             auto &prev         = self->platform->prev_decoration;
             const auto current = self->decorations();
 
-            if (prev.has_value() && *prev == current)
+            if (prev == current)
             {
                 return;
             }

--- a/src/win32.window.impl.cpp
+++ b/src/win32.window.impl.cpp
@@ -114,7 +114,7 @@ namespace saucer
             auto &prev         = self->platform->prev_decoration;
             const auto current = self->decorations();
 
-            if (prev.has_value() && *prev == current)
+            if (prev == current)
             {
                 break;
             }

--- a/src/wkg.webview.cpp
+++ b/src/wkg.webview.cpp
@@ -251,7 +251,7 @@ namespace saucer
 
     void impl::set_bounds(saucer::bounds bounds) // NOLINT(*-function-const)
     {
-        auto [width, height] = window->size();
+        auto [width, height] = window->native<false>()->platform->offset<offset::add>(window->size());
         auto *const widget   = GTK_WIDGET(platform->web_view);
 
         gtk_widget_set_margin_start(widget, bounds.x);

--- a/src/wkg.webview.cpp
+++ b/src/wkg.webview.cpp
@@ -11,6 +11,8 @@
 
 #include <cassert>
 
+#include <adwaita.h>
+
 namespace saucer
 {
     using impl = webview::impl;

--- a/src/wkg.webview.cpp
+++ b/src/wkg.webview.cpp
@@ -174,7 +174,7 @@ namespace saucer
 
     bounds impl::bounds() const
     {
-        auto [width, height] = window->size();
+        auto [width, height] = window->native<false>()->platform->offset<offset::add>(window->size());
         auto *const widget   = GTK_WIDGET(platform->web_view);
 
         const auto x = gtk_widget_get_margin_start(widget);

--- a/tests/src/regression.test.cpp
+++ b/tests/src/regression.test.cpp
@@ -47,6 +47,7 @@ suite<"regression"> regression_suite = []
         webview.set_url("https://codeberg.org/saucer/saucer");
 
         saucer::tests::wait_for([&order] { return order.size() == 4; }, duration);
+        expect(eq(order.size(), 4));
 
         expect(eq(order.at(0), 1));
         expect(eq(order.at(1), 2));


### PR DESCRIPTION
This PR makes it possible to use a normal GTK4 window instead of an Adwaita one. This can be achieved through setting the CMake option `saucer_adwaita` to `OFF`.

The dependency on Adwaita is not removed however, as we still rely on it in the webview for forcing a dark theme.  

---

As it came up during testing, this PR also introduces some changes for detecting resizes, as on some window managers, e.g. Hyprland, I noticed that the default-size is not changed when resizing, while on e.g. KDE, it is changed, thus breaking custom bounds for said window managers.

I have also introduced a `g_widget_ptr` which will only delete widgets if they have no parent (which would normally clean them up automatically).