### PR TITLE
fix(cmake): NUGET unset if local exe is present

### DIFF
--- a/cmake/nuget.cmake
+++ b/cmake/nuget.cmake
@@ -8,13 +8,13 @@ function(nuget_setup OUTPUT)
 
     if (NOT EXISTS "${nuget_PATH}")
         find_program(NUGET nuget)
-    endif()
 
-    if (NUGET MATCHES "NOTFOUND")
-        file(DOWNLOAD "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" "${nuget_PATH}")
-        nuget_message(STATUS "Downloading to '${nuget_PATH}'")
-    else()
-        set(nuget_PATH "${NUGET}")
+        if (NUGET MATCHES "NOTFOUND")
+            file(DOWNLOAD "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" "${nuget_PATH}")
+            nuget_message(STATUS "Downloading to '${nuget_PATH}'")
+        else()
+            set(nuget_PATH "${NUGET}")
+        endif()
     endif()
 
     # Ensure that the default NuGet-Sources are present


### PR DESCRIPTION
If the local nuget is found in _deps then the if returns false and find_package does not get run; making NUGET unset.
This makes it go to the else statement afterwards and sets nuget_PATH to something empty and then later tries to run it. This commit fixes that
